### PR TITLE
Fix image mode to work without public video and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Option        | Type     | Default | Description
 `size`        | `string` | `large` | One of the following sizes: `large`, `medium`, `small`, `mini`
 `mode`        | `string` | `image` | One of the following sizes: `image`, `video`
 
-NOTE:  Due to Nest API restrictions you must have your cameras set [shared publicly without a password](https://nest.com/support/article/How-do-I-make-my-Nest-Cam-video-public-or-private#without-password) for `video` mode to work. `video` mode currently requires you to click the video to start playback.  The embedded iframe URL is supposed to autoplay, but it looks like this is not supported inside electron without user interaction.
+NOTE:  Due to Nest API restrictions you must have your cameras [shared publicly without a password](https://nest.com/support/article/How-do-I-make-my-Nest-Cam-video-public-or-private#without-password) for `video` mode to work. `video` mode currently requires you to click the video to start playback.  The embedded iframe URL is supposed to autoplay, but it looks like this is not supported inside electron without user interaction.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Option        | Type     | Default | Description
 `size`        | `string` | `large` | One of the following sizes: `large`, `medium`, `small`, `mini`
 `mode`        | `string` | `image` | One of the following sizes: `image`, `video`
 
-NOTE:  The `video` mode currently requires you to click the video to start playback.  The embedded iframe URL is supposed to autoplay, but it looks like this is not supported inside electron without user interaction.
+NOTE:  Due to Nest API restrictions you must have your cameras set [shared publicly without a password](https://nest.com/support/article/How-do-I-make-my-Nest-Cam-video-public-or-private#without-password) for `video` mode to work. `video` mode currently requires you to click the video to start playback.  The embedded iframe URL is supposed to autoplay, but it looks like this is not supported inside electron without user interaction.

--- a/nest.js
+++ b/nest.js
@@ -1,21 +1,33 @@
-var getCameras = function(config, callback) {
-  if (!config || !config.token) {
-    return callback({ success: false, message: 'Please run getNestToken.sh and put your token in the config.js file', data: null });
-  }
+var getCameras = function (config, callback) {
+	if (!config || !config.token) {
+		return callback({
+			success: false,
+			message: 'Please run getNestToken.sh and put your token in the config.js file',
+			data: null
+		});
+	}
 
-  var url = 'https://developer-api.nest.com/devices?auth=' + config.token;
-  var req = new XMLHttpRequest();
-  req.open('GET', url, true);
-  req.onreadystatechange = function () {
-    if (this.readyState === 4) {
-      if (this.status === 200) {
-        if (this.response == '{}') {
-					return callback({ success: true, message: 'Token works, but no data received. Make sure you are using the master account.', data: null });
-        } else {
+	var url = 'https://developer-api.nest.com/devices?auth=' + config.token;
+	var req = new XMLHttpRequest();
+	req.open('GET', url, true);
+	req.onreadystatechange = function () {
+		if (this.readyState === 4) {
+			if (this.status === 200) {
+				if (this.response == '{}') {
+					return callback({
+						success: true,
+						message: 'Token works, but no data received. Make sure you are using the master account.',
+						data: null
+					});
+				} else {
 					var data = JSON.parse(this.response);
 
 					if (!data.cameras || JSON.stringify(data.cameras) === '{}') {
-						return callback({ success: true, message: 'No Cameras.', data: null });
+						return callback({
+							success: true,
+							message: 'No Cameras.',
+							data: null
+						});
 					}
 
 					var cameras = [];
@@ -32,18 +44,33 @@ var getCameras = function(config, callback) {
 								cameras.push({
 									name: cam.where_name,
 									video: cam.public_share_url.replace('video.nest.com/live', 'video.nest.com/embedded/live') + '?autoplay=1&playsinline=1&webkit-playsinline=1&mute=1&controls=0',
-                  image: cam.snapshot_url
+									image: cam.snapshot_url
+								});
+							}
+						} else if (cam.is_online) {
+							if (!config.whereFilter || (typeof config.whereFilter === 'object' && config.whereFilter.length > 0 && config.whereFilter.indexOf(cam.where_name) > -1)) {
+								cameras.push({
+									name: cam.where_name,
+									image: cam.snapshot_url
 								});
 							}
 						}
 					}
 
-          return callback({ success: true, message: null, data: cameras });
-        }
-      } else {
-				return callback({ success: false, message: 'Nest Error - Status: ' + this.status, data: null })
-      }
-    }
-  };
-  req.send();
+					return callback({
+						success: true,
+						message: null,
+						data: cameras
+					});
+				}
+			} else {
+				return callback({
+					success: false,
+					message: 'Nest Error - Status: ' + this.status,
+					data: null
+				})
+			}
+		}
+	};
+	req.send();
 }


### PR DESCRIPTION
Currently, the way this is written if someone only wants to use `image` mode without publicly sharing their video they are unable to. This creates a new `else if` below the initial `if` statement to check if the camera is online and if so only grab the image information. Updated some formatting for readability.

Also updated the README to explicitly state that `video` mode will only work if the camera is shared publicly.

Thanks so much for making this module! It is awesome!